### PR TITLE
Fix AttributeError when specifying arguments

### DIFF
--- a/git-upload
+++ b/git-upload
@@ -44,7 +44,8 @@ def main(argv=sys.argv):
             else:
                 print('Canceled')
         else:
-            git_push = ['git', 'push'].extends(argv[1:])
+            git_push = ['git', 'push']
+            git_push.extend(argv[1:])
             subprocess.call(git_push, stdout=sys.stdout)
 
 


### PR DESCRIPTION
This commit fixes the AttributeError when specifying
arguments. 'extends' is wrong but 'extend'.

fixes #14