### PR TITLE
Handle gerrit repository more proper way

### DIFF
--- a/git-upload
+++ b/git-upload
@@ -11,6 +11,7 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+from os import path
 import subprocess
 import sys
 from builtins import input
@@ -21,8 +22,7 @@ args = sys.argv
 def main(argv=sys.argv):
     origin_url = subprocess.check_output(['git', 'config', '--get',
                                           'remote.origin.url']).decode('utf-8')
-    if origin_url.startswith('https://review.openstack.org/') or \
-       origin_url.startswith('git://git.openstack.org/'):
+    if path.isfile('.gitreview'):
         # Gerrit
         git_review = ['git', 'review']
         git_review.extend(argv[1:])


### PR DESCRIPTION
This commit changes to handle a gerrit repository more proper way. I
think this works in most of the case. If people wants to push a patch
to a simple git repo like GitHub, they should use `git push` directly.

Fixes #8