### PR TITLE
Use py36 for Python3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ classifier =
     Programming Language :: Python :: 2
     Programming Language :: Python :: 2.7
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Topic :: Software Development :: Version Control
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.6
-envlist = py36,py35,py34,py27,pep8
+envlist = py36,py27,pep8
 skipsdist = True
 
 [testenv]


### PR DESCRIPTION
This commit removes py34, py35 usage from setup.cfg and tox.ini. I
probably don't need these versions.